### PR TITLE
In REAMDE, correct dead link to OA REST API documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ## Third party libraries:
 
 ### Json.NET Library (http://json.codeplex.com/)
-####License:
+####  License:
 
 Copyright (c) 2007 James Newton-King
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ C# library &amp; sample code for using the OpenAsset REST API v1
 
 ## Documentation
 The documentation for the REST API endpoints used by this library can be found at:
-http://help.openasset.com/06_Integration/REST_API
+https://developers.openasset.com/
 
 ### Sample Usage
 The examples below show how to establish a connection to OpenAsset and get/send data.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ C# library &amp; sample code for using the OpenAsset REST API v1
 
 ## Documentation
 > [!TIP]
+> Additional information about developing custom integrations using the OpenAsset REST API can also be found in [this support article](https://success.openasset.com/en/articles/3122502-developing-custom-integrations-using-the-openasset-rest-api).
+>
 > The documentation for the REST API endpoints used by this library can be found at:
 https://developers.openasset.com/
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 C# library &amp; sample code for using the OpenAsset REST API v1
 
 ## Documentation
-The documentation for the REST API endpoints used by this library can be found at:
+> [!TIP]
+> The documentation for the REST API endpoints used by this library can be found at:
 https://developers.openasset.com/
 
 ### Sample Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The documentation for the REST API endpoints used by this library can be found a
 http://help.openasset.com/06_Integration/REST_API
 
 ### Sample Usage
-The examples below show how to establish connection to OpenAsset and get/send data.
+The examples below show how to establish a connection to OpenAsset and get/send data.
 
 ```csharp
 // import library directives
@@ -21,7 +21,7 @@ string baseURL = "http://localhost";
 string password = "password";
 string username = "username";
 
-// Establish connection to OpenAsset
+// Establish a connection to OpenAsset
 Connection conn = Connection.GetConnection(baseURL, username, password);
 
 // Verify credentials


### PR DESCRIPTION
 - Correct link to current documentation site 
    - Placed in a nice tip box, utilising markdown as outlined in [community/discussions/16925](https://github.com/orgs/community/discussions/16925)
 - Add a link to support article about developing custom integrations using the OpenAsset REST API
 - One minor grammar fix
 - Fix licencing subheading Markdown 

Rich diff for this change can be viewed [here](https://github.com/axomic/openasset-rest-cs/pull/6/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).